### PR TITLE
Choose Your Authentication Adventure

### DIFF
--- a/app/controllers/cookie_authentications_controller.rb
+++ b/app/controllers/cookie_authentications_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'browser'
+
+# Provides the means to authenticate and store the access token in a secure HTTP cookie that the
+# client/caller cannot bugger with.
+#
+# A CSRF token is returned from a successful authentication interaction and will be required for all
+# DELETE/PATCH/PUT actions going forward while authentication is stored in the HTTP cookie.
+#
+# The access token stored in the cookie will eventually expire and need to be re-issued in
+# partnership with the associated refresh token that remains guarded on the server side.
+#
+# Session information is collected during login.  This is mostly pulled from the User-Agent header.  But it
+# is important to note that the RUID to the refresh token stored in Redis is recorded to the `Session`.  Doing this
+# allows a session to be identified and potentially invalidated by the owning user or administrators.
+class CookieAuthenticationsController < ApplicationController
+  before_action :authorize_access_request!, only: [:destroy]
+
+  # login
+  def create
+    user = User.find_by!(email: params[:email])
+
+    raise JWTSessions::Errors::Unauthorized, 'Authentication failed' unless user.authenticate(params[:password])
+
+    # got here, means authentication was sucessful
+
+    payload = { user_id: user.id }
+    session = JWTSessions::Session.new(payload: payload, refresh_by_access_allowed: true)
+    tokens = session.login
+
+    response.set_cookie(
+      JWTSessions.access_cookie,
+      value: tokens[:access],
+      httponly: true,
+      path: '/',
+      secure: Rails.env.production?
+    )
+
+    # record session information in the database for administrative use
+    browser = Browser.new(request.headers['User-Agent'])
+    Session.create!(
+      browser: browser.name,
+      browser_version: browser.full_version,
+      device: browser.device.name,
+      expiring_at: tokens[:refresh_expires_at],
+      ip_address: request.remote_ip,
+      platform: browser.platform.name,
+      platform_version: browser.platform.version,
+      ruid: session.payload['ruid'],
+      user: user
+    )
+
+    render json: { csrf: tokens[:csrf] }, status: :created
+  end
+
+  # logout
+  def destroy
+    jwt_session = JWTSessions::Session.new(payload: payload)
+    jwt_session.flush_by_access_payload
+
+    response.delete_cookie JWTSessions.access_cookie
+
+    Session.find_by(ruid: payload['ruid']).update!(invalidated: true, invalidated_by: current_user)
+
+    render json: { data: {}, meta: {} }, status: :no_content
+  end
+end

--- a/app/controllers/refresh_cookies_controller.rb
+++ b/app/controllers/refresh_cookies_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# This controller is responsible for refreshing access tokens that have expired.
+# This controller is responsible for refreshing access tokens that have expired and that are stored securely
+# as http cookies.
 #
 # JWTSessions does not appear to respect RefreshToken expiry in its workflow, so it is up to this
 # implementation to `:authorize_refresh_not_expired!`.  Should a refresh token hit its expiry, we
@@ -9,7 +10,7 @@
 # Otherwise, we will attempt to refresh the access token so that it can continue accessing resources.  Attempts
 # to refresh an access token prior to its expiry will be flush the session and produce a 401 UNAUTHORIZED response
 # that will describe the refresh attempt as 'Malicious activity detected'.
-class RenewalsController < ApplicationController
+class RefreshCookiesController < ApplicationController
   # first authorize the request (CSRF etc.)
   before_action :authorize_refresh_by_access_request!
   # second authorize that the refresh token has not expired
@@ -35,6 +36,7 @@ class RenewalsController < ApplicationController
       JWTSessions.access_cookie,
       value: tokens[:access],
       httponly: true,
+      path: '/',
       secure: Rails.env.production?
     )
 

--- a/app/controllers/refresh_tokens_controller.rb
+++ b/app/controllers/refresh_tokens_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# This controller is responsible for refreshing access tokens that are being passed in the request header
+# and that have expired.  A refresh token is not required.
+#
+# JWTSessions does not appear to respect RefreshToken expiry in its workflow, so it is up to this
+# implementation to `:authorize_refresh_not_expired!`.  Should a refresh token hit its expiry, we
+# will actually send back a 401 UNAUTHORIZED with the message 'Session has expired'.
+#
+# Otherwise, we will attempt to refresh the access token so that it can continue accessing resources.  Attempts
+# to refresh an access token prior to its expiry will be flush the session and produce a 401 UNAUTHORIZED response
+# that will describe the refresh attempt as 'Malicious activity detected'.
+class RefreshTokensController < ApplicationController
+  # first authorize the request (CSRF etc.)
+  before_action :authorize_refresh_by_access_request!
+  # second authorize that the refresh token has not expired
+  before_action :authorize_refresh_not_expired!
+
+  def create
+    session = JWTSessions::Session.new(payload: claimless_payload, refresh_by_access_allowed: true)
+
+    tokens = session.refresh_by_access_payload do |_refresh_token_uid, _access_token_expiration|
+      # this block only fires if the access token has not yet expired
+      Rails.logger.warn "Malicious activity from #{current_user.email}.  Destroy their session."
+
+      session.flush_by_access_payload
+
+      # TODO: do we need to trigger an email to inform of malicious activity?
+
+      raise JWTSessions::Errors::Unauthorized, 'Malicious activity detected'
+    end
+
+    render json: { access: tokens[:access] }, status: :created
+  end
+
+  private
+
+  def authorize_refresh_not_expired!
+    raise JWTSessions::Errors::Unauthorized, 'Session has expired' if Time.now > refresh_token_expiration
+  end
+
+  def refresh_token_expiration
+    Time.at(JWTSessions::RefreshToken.find(claimless_payload['ruid'], JWTSessions.token_store).expiration.to_i)
+  end
+end

--- a/app/controllers/token_authentications_controller.rb
+++ b/app/controllers/token_authentications_controller.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
-require 'browser'
-
-# Provides the means to authenticate and have the access token stored in a secure HTTP cookie that the
-# client/caller cannot bugger with.
+# Provides the means to authenticate and be issued the encrypted access token.  It is
+# expected that you will provide the access token with every request for protected resources.
 #
-# A CSRF token is returned from a successful authentication interaction and will be required for all
-# DELETE/PATCH/PUT actions going forward while authentication is stored in the HTTP cookie.
+# The access token will eventually expire and need to be re-issued in partnership with the associated refresh
+# token that remains guarded on the server side.
 #
 # Session information is collected during login.  This is mostly pulled from the User-Agent header.  But it
 # is important to note that the RUID to the refresh token stored in Redis is recorded to the `Session`.  Doing this
 # allows a session to be identified and potentially invalidated by the owning user or administrators.
-class AuthenticationsController < ApplicationController
+class TokenAuthenticationsController < ApplicationController
   before_action :authorize_access_request!, only: [:destroy]
 
   # login
@@ -25,13 +23,6 @@ class AuthenticationsController < ApplicationController
     payload = { user_id: user.id }
     session = JWTSessions::Session.new(payload: payload, refresh_by_access_allowed: true)
     tokens = session.login
-
-    response.set_cookie(
-      JWTSessions.access_cookie,
-      value: tokens[:access],
-      httponly: true,
-      secure: Rails.env.production?
-    )
 
     # record session information in the database for administrative use
     browser = Browser.new(request.headers['User-Agent'])
@@ -47,15 +38,13 @@ class AuthenticationsController < ApplicationController
       user: user
     )
 
-    render json: { csrf: tokens[:csrf] }, status: :created
+    render json: { access: tokens[:access] }, status: :created
   end
 
   # logout
   def destroy
     jwt_session = JWTSessions::Session.new(payload: payload)
     jwt_session.flush_by_access_payload
-
-    response.delete_cookie JWTSessions.access_cookie
 
     Session.find_by(ruid: payload['ruid']).update!(invalidated: true, invalidated_by: current_user)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  post '/login', to: 'authentications#create'
-  delete '/logout', to: 'authentications#destroy'
-  post '/renew', to: 'renewals#create'
+  post '/cookie/login', to: 'cookie_authentications#create'
+  delete '/cookie/logout', to: 'cookie_authentications#destroy'
+  post '/cookie/refresh', to: 'refresh_cookies#create'
+  post '/token/login', to: 'token_authentications#create'
+  delete '/token/logout', to: 'token_authentications#destroy'
+  post '/token/refresh', to: 'refresh_tokens#create'
 
   namespace :api, constraints: { format: :json } do
     namespace :v1 do

--- a/test/controllers/cookie_authentications_controller_test.rb
+++ b/test/controllers/cookie_authentications_controller_test.rb
@@ -2,10 +2,10 @@
 
 require 'test_helper'
 
-class AuthenticationsControllerTest < ActionDispatch::IntegrationTest
+class CookieAuthenticationsControllerTest < ActionDispatch::IntegrationTest
   test 'when logging in fails because the email is missing' do
     assert_no_difference ['Session.count'] do
-      post login_url
+      post cookie_login_url
     end
 
     assert_response :not_found
@@ -14,7 +14,7 @@ class AuthenticationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'when logging in fails because the password is missing' do
     assert_no_difference ['Session.count'] do
-      post login_url, params: { email: 'sterling@isiservice.com' }
+      post cookie_login_url, params: { email: 'sterling@isiservice.com' }
     end
 
     assert_response :unauthorized
@@ -23,16 +23,16 @@ class AuthenticationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'when logging in fails because the email and password do not match' do
     assert_no_difference ['Session.count'] do
-      post login_url, params: { email: 'sterling@isiservice.com', password: 'secrets' }
+      post cookie_login_url, params: { email: 'sterling@isiservice.com', password: 'secrets' }
     end
 
     assert_response :unauthorized
     refute cookies[JWTSessions.access_cookie].present?
   end
 
-  test 'when logging is successful' do
+  test 'when logging in is successful' do
     assert_difference ['Session.count'] do
-      post login_url, headers: { 'User-Agent': USER_AGENT }, params: { email: 'sterling@isiservice.com', password: 'secret' }
+      post cookie_login_url, headers: { 'User-Agent': USER_AGENT }, params: { email: 'sterling@isiservice.com', password: 'secret' }
     end
 
     assert_response :created
@@ -40,7 +40,7 @@ class AuthenticationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'when logging out without a session' do
-    delete logout_url
+    delete cookie_logout_url
 
     assert_response :unauthorized
     assert_equal 'Token is not found', JSON.parse(response.body)['errors'].first['detail']
@@ -55,7 +55,7 @@ class AuthenticationsControllerTest < ActionDispatch::IntegrationTest
 
     assert cookies[JWTSessions.access_cookie].present?
 
-    delete logout_url, headers: @headers
+    delete cookie_logout_url, headers: @headers
 
     assert_response :no_content
     refute cookies[JWTSessions.access_cookie].present?
@@ -72,7 +72,7 @@ class AuthenticationsControllerTest < ActionDispatch::IntegrationTest
 
     refute sterling.sessions.first.invalidated?
 
-    delete logout_url, headers: @headers
+    delete cookie_logout_url, headers: @headers
 
     assert_response :no_content
     assert sterling.sessions.first.invalidated?

--- a/test/controllers/refresh_cookies_controller_test.rb
+++ b/test/controllers/refresh_cookies_controller_test.rb
@@ -2,9 +2,9 @@
 
 require 'test_helper'
 
-class RenewalsControllerTest < ActionDispatch::IntegrationTest
+class RefreshCookiesControllerTest < ActionDispatch::IntegrationTest
   test 'when attempting to renew access token without an access cookie' do
-    post renew_url
+    post cookie_refresh_url
 
     assert_response :unauthorized
   end
@@ -12,7 +12,7 @@ class RenewalsControllerTest < ActionDispatch::IntegrationTest
   test 'when attempting to renew access token but without supplying the csrf token' do
     login(users(:sterling_archer))
 
-    post renew_url
+    post cookie_refresh_url
 
     assert_response :unauthorized
   end
@@ -24,7 +24,7 @@ class RenewalsControllerTest < ActionDispatch::IntegrationTest
 
     Timecop.travel((JWTSessions.access_exp_time - 1).seconds.from_now)
 
-    post renew_url, headers: @headers
+    post cookie_refresh_url, headers: @headers
 
     # TODO: sometimes this assertion fails; if you re-run the test it might work.  Timecop must be fucked?
     assert_response :unauthorized
@@ -38,7 +38,7 @@ class RenewalsControllerTest < ActionDispatch::IntegrationTest
 
     Timecop.travel((JWTSessions.access_exp_time + 1).seconds.from_now)
 
-    post renew_url, headers: @headers
+    post cookie_refresh_url, headers: @headers
 
     assert_response :created
   end
@@ -50,7 +50,7 @@ class RenewalsControllerTest < ActionDispatch::IntegrationTest
 
     Timecop.travel((JWTSessions.access_exp_time + 1).seconds.from_now)
 
-    post renew_url, headers: @headers
+    post cookie_refresh_url, headers: @headers
 
     assert_response :created
 
@@ -74,26 +74,26 @@ class RenewalsControllerTest < ActionDispatch::IntegrationTest
     assert_response :no_content, 'Re-issued CSRF token was used, delete should complete successfully'
   end
 
-  test 'when token refresh succeeds one second BEFORE REFRESH expiry' do
+  test 'when refresh of access token succeeds one second BEFORE REFRESH expiry' do
     Timecop.freeze
 
     login(users(:sterling_archer))
 
     Timecop.travel((JWTSessions.refresh_exp_time - 1).seconds.from_now)
 
-    post renew_url, headers: @headers
+    post cookie_refresh_url, headers: @headers
 
     assert_response :created
   end
 
-  test 'when token refresh fails one second AFTER REFRESH expiry' do
+  test 'when refresh of access token fails one second AFTER REFRESH expiry' do
     Timecop.freeze
 
     login(users(:sterling_archer))
 
     Timecop.travel((JWTSessions.refresh_exp_time + 1).seconds.from_now)
 
-    post renew_url, headers: @headers
+    post cookie_refresh_url, headers: @headers
 
     assert_response :unauthorized
     assert_equal 'Session has expired', JSON.parse(response.body)['errors'].first['detail']

--- a/test/controllers/refresh_tokens_controller_test.rb
+++ b/test/controllers/refresh_tokens_controller_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RefreshTokensControllerTest < ActionDispatch::IntegrationTest
+  test 'when attempting to renew access token without an access cookie' do
+    post token_refresh_url
+
+    assert_response :unauthorized
+  end
+
+  test 'when renewing an access token one second before access-expiry' do
+    Timecop.freeze
+
+    token(users(:sterling_archer))
+
+    Timecop.travel((JWTSessions.access_exp_time - 1).seconds.from_now)
+
+    post token_refresh_url, headers: @headers
+
+    # TODO: sometimes this assertion fails; if you re-run the test it might work.  Timecop must be fucked?
+    assert_response :unauthorized
+    assert_equal 'Malicious activity detected', JSON.parse(response.body)['errors'].first['detail']
+  end
+
+  test 'when renewing an access token one second after access-expiry' do
+    Timecop.freeze
+
+    token(users(:sterling_archer))
+
+    Timecop.travel((JWTSessions.access_exp_time + 1).seconds.from_now)
+
+    post token_refresh_url, headers: @headers
+
+    assert_response :created
+    assert JSON.parse(response.body)['access']
+    assert_not_equal @access_token, JSON.parse(response.body)['access']
+  end
+
+  test 'when refresh of access token succeeds one second BEFORE REFRESH expiry' do
+    Timecop.freeze
+
+    token(users(:sterling_archer))
+
+    Timecop.travel((JWTSessions.refresh_exp_time - 1).seconds.from_now)
+
+    post token_refresh_url, headers: @headers
+
+    assert_response :created
+    assert JSON.parse(response.body)['access']
+    assert_not_equal @access_token, JSON.parse(response.body)['access']
+  end
+
+  test 'when refresh of access token fails one second AFTER REFRESH expiry' do
+    Timecop.freeze
+
+    login(users(:sterling_archer))
+
+    Timecop.travel((JWTSessions.refresh_exp_time + 1).seconds.from_now)
+
+    post token_refresh_url, headers: @headers
+
+    assert_response :unauthorized
+    assert_equal 'Session has expired', JSON.parse(response.body)['errors'].first['detail']
+  end
+
+  test 'when renewing an access token and performing a DELETE with the new token' do
+    Timecop.freeze
+
+    token(users(:sterling_archer))
+
+    Timecop.travel((JWTSessions.access_exp_time + 1).seconds.from_now)
+
+    # delete should fail because access token is expired
+    assert_no_difference ['User.count'] do
+      delete api_v1_protected_user_url(users(:mallory_archer).id), headers: @headers
+    end
+    assert_response :unauthorized
+
+    # renew the access token
+    post token_refresh_url, headers: @headers
+
+    assert_response :created
+    assert_not_equal @access_token, JSON.parse(response.body)['access']
+
+    # set up the request header hash with the renewed access token
+    new_headers = {}
+    new_headers[JWTSessions.access_header] = JSON.parse(response.body)['access']
+
+    # now attempt to delete with the renewed access token
+    assert_difference ['User.count'], -1 do
+      delete api_v1_protected_user_url(users(:mallory_archer).id), headers: new_headers
+    end
+    assert_response :no_content, 'Delete was successful'
+  end
+end

--- a/test/controllers/token_authentications_controller_test.rb
+++ b/test/controllers/token_authentications_controller_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TokenAuthenticationsControllerTest < ActionDispatch::IntegrationTest
+  test 'when logging in fails because the email is missing' do
+    assert_no_difference ['Session.count'] do
+      post token_login_url
+    end
+
+    assert_response :not_found
+  end
+
+  test 'when logging in fails because the password is missing' do
+    assert_no_difference ['Session.count'] do
+      post token_login_url, params: { email: 'sterling@isiservice.com' }
+    end
+
+    assert_response :unauthorized
+  end
+
+  test 'when logging in fails because the email and password do not match' do
+    assert_no_difference ['Session.count'] do
+      post token_login_url, params: { email: 'sterling@isiservice.com', password: 'secrets' }
+    end
+
+    assert_response :unauthorized
+  end
+
+  test 'when logging in is successful' do
+    assert_difference ['Session.count'] do
+      post token_login_url, headers: { 'User-Agent': USER_AGENT }, params: { email: 'sterling@isiservice.com', password: 'secret' }
+    end
+
+    assert_response :created
+    tokens = JSON.parse(response.body)
+    assert tokens['access'].present?
+    refute tokens['refresh'].present?
+  end
+
+  test 'when logging out without a session' do
+    delete token_logout_url
+
+    assert_response :unauthorized
+    assert_equal 'Token is not found', JSON.parse(response.body)['errors'].first['detail']
+  end
+
+  test 'when logging out successfully the Session invalidated fields are updated' do
+    Timecop.freeze
+
+    sterling = users(:sterling_archer)
+
+    token(sterling)
+
+    Timecop.travel 15.minutes.from_now
+
+    refute sterling.sessions.first.invalidated?
+
+    delete token_logout_url, headers: @headers
+
+    assert_response :no_content
+    assert sterling.sessions.first.invalidated?
+    assert sterling.sessions.first.invalidated_by.present?
+  end
+
+  test 'when accessing a protected resource with token authentication' do
+    Timecop.freeze
+
+    sterling = users(:sterling_archer)
+
+    token(sterling)
+
+    Timecop.travel 15.minutes.from_now
+
+    get api_v1_protected_users_url, headers: @headers
+
+    assert_response :ok
+    assert_equal 2, JSON.parse(response.body)['data'].length
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,20 +20,36 @@ module ActiveSupport
       Timecop.return
     end
 
-    # Helper to log a given user in
+    # Helper to log a given user in with cookie based authentication
     # @return headers with the `X-CSRF-Token` assigned; you must pass this to your HTTP actions (e.g. `get v1_users_url, headers: @headers`)
     def login(user, options = {})
       password = options[:password] || 'secret' # default 'secret'
 
       Rails.logger.info '------------------------------------------------------------------------------------------'
-      Rails.logger.info "Logging in as #{user.email}"
+      Rails.logger.info "Cookie Authentication as #{user.email}"
       Rails.logger.info '------------------------------------------------------------------------------------------'
 
-      post login_url, headers: { 'User-Agent': USER_AGENT }, params: { email: user.email, password: password }
+      post cookie_login_url, headers: { 'User-Agent': USER_AGENT }, params: { email: user.email, password: password }
 
       @csrf_token = ::JSON.parse(response.body)['csrf']
       @headers = {}
       @headers[JWTSessions.csrf_header] = @csrf_token
+    end
+
+    # Helper to log a given user in with cookie based authentication
+    # @return headers with the `X-CSRF-Token` assigned; you must pass this to your HTTP actions (e.g. `get v1_users_url, headers: @headers`)
+    def token(user, options = {})
+      password = options[:password] || 'secret' # default 'secret'
+
+      Rails.logger.info '------------------------------------------------------------------------------------------'
+      Rails.logger.info "Token Authentication as #{user.email}"
+      Rails.logger.info '------------------------------------------------------------------------------------------'
+
+      post token_login_url, headers: { 'User-Agent': USER_AGENT }, params: { email: user.email, password: password }
+
+      @access_token = ::JSON.parse(response.body)['access']
+      @headers = {}
+      @headers[JWTSessions.access_header] = @access_token
     end
   end
 end


### PR DESCRIPTION
Cookie stored access tokens combined with a CSRF token is the safest form of session management combined with JWT because you are completely resilient from XSS attacks.  Request forgery attacks are mitigated by CSRF token.  See `CookieAuthenticationsController` & `RefreshCookiesController`.

An access token can be willfully passed down to your client application, but it is not recommended to use this technique for web pages or SPAs.  See `TokenAuthenticationsController` & `RefreshTokensController`.

All of these new controllers are well tested.  All classes have  detailed class comments.

See issue #8 